### PR TITLE
Allow setting max_burst when instantiating the Limiter

### DIFF
--- a/asynciolimiter.py
+++ b/asynciolimiter.py
@@ -273,7 +273,7 @@ class Limiter(_CommonLimiterMixin):
         rate: The rate (calls per second) at which the limiter should let
         traffic through.
     """
-    def __init__(self, rate: float, max_burst: int = 5) -> None:
+    def __init__(self, rate: float, *, max_burst: int = 5) -> None:
         """Create a new limiter.
 
         Args:

--- a/asynciolimiter.py
+++ b/asynciolimiter.py
@@ -284,7 +284,7 @@ class Limiter(_CommonLimiterMixin):
         super().__init__()
         self._rate = rate
         self._time_between_calls = 1 / rate
-        self._max_burst = max_burst
+        self.max_burst = max_burst
 
     def __repr__(self):
         cls = self.__class__
@@ -304,16 +304,6 @@ class Limiter(_CommonLimiterMixin):
         """
         self._rate = value
         self._time_between_calls = 1 / value
-
-    @property
-    def max_burst(self) -> int:
-        """In case there's a delay, schedule no more than this many calls at once."""
-        return self._max_burst
-
-    @max_burst.setter
-    def max_burst(self, value: int) -> None:
-        """Set how many calls at once can be scheduled in case there's a delay."""
-        self._max_burst = value
 
     def _maybe_lock(self):
         """Lock the limiter as soon a request passes through."""
@@ -375,7 +365,7 @@ class Limiter(_CommonLimiterMixin):
 
         # Attempt to wake up only the missed wakeups and ones that were
         # inserted while we missed the original wakeup.
-        to_wakeup = min(int(missed_wakeups) + 1, self._max_burst)
+        to_wakeup = min(int(missed_wakeups) + 1, self.max_burst)
 
         while to_wakeup and self._waiters:
             waiter = self._waiters.popleft()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -117,7 +117,7 @@ to ensure smooth traffic.
 Implementations
 ****************
 
-.. class:: Limiter(rate)
+.. class:: Limiter(rate, *, max_burst = 5)
 
     Regular limiter, with a max burst compensating for delayed schedule.
     
@@ -141,7 +141,8 @@ Implementations
 
     .. code::
 
-        >>> limiter = Limiter(5)  # 5 calls per second.
+        >>> # 5 calls per second; up to 10 calls at once if there's a delay
+        >>> limiter = Limiter(5, max_burst=10)
         >>> async def request():
         ...     await limiter.wait()
         ...     print("Request")  # Do stuff

--- a/tests.py
+++ b/tests.py
@@ -66,7 +66,7 @@ class LimiterTestCase(CommonTestsMixin, PatchLoopMixin,
                       IsolatedAsyncioTestCase):
     def setUp(self):
         super().setUp()
-        self.limiter = Limiter(1 / 3)
+        self.limiter = Limiter(1 / 3, max_burst=3)
 
     async def test_wait(self):
         await self.limiter.wait()
@@ -78,6 +78,10 @@ class LimiterTestCase(CommonTestsMixin, PatchLoopMixin,
         self.add_waiter()
         await self.advance_loop()
         self.assert_call_at(2)
+
+    async def test_max_burst_setter(self):
+        self.limiter.max_burst = 10
+        self.assertEqual(self.limiter.max_burst, 10)
 
     async def test_repr(self):
         self.assertEqual(eval(repr(self.limiter)).rate, self.limiter.rate)
@@ -156,7 +160,6 @@ class LimiterTestCase(CommonTestsMixin, PatchLoopMixin,
             self.call_wakeup()
 
     async def test_wait_multiple_max_burst(self):
-        self.limiter.max_burst = 3
         for i in range(5):
             self.add_waiter()
         await self.advance_loop()

--- a/tests.py
+++ b/tests.py
@@ -84,10 +84,6 @@ class LimiterTestCase(CommonTestsMixin, PatchLoopMixin,
         await self.advance_loop()
         self.assert_call_at(2)
 
-    async def test_max_burst_setter(self):
-        self.limiter.max_burst = 10
-        self.assertEqual(self.limiter.max_burst, 10)
-
     async def test_repr(self):
         self.assertEqual(eval(repr(self.limiter)).rate, self.limiter.rate)
 

--- a/tests.py
+++ b/tests.py
@@ -68,6 +68,11 @@ class LimiterTestCase(CommonTestsMixin, PatchLoopMixin,
         super().setUp()
         self.limiter = Limiter(1 / 3, max_burst=3)
 
+    def test_init_keyword_only(self):
+        assert Limiter(1.0, max_burst=5).max_burst == 5
+        with self.assertRaises(TypeError):
+            Limiter(1.0, 5)
+
     async def test_wait(self):
         await self.limiter.wait()
         self.loop.call_at.assert_called_once_with(3, ANY)


### PR DESCRIPTION
`max_burst` is now an argument to `Limiter.__init__`.
There's a protected `_max_burst` attribute, and a getter and setter for it.

Tests were adjusted accordingly.

By the way, thanks for the great package. :)